### PR TITLE
feat: allow to specify `assetType` filter in the URL

### DIFF
--- a/components/TokenList.vue
+++ b/components/TokenList.vue
@@ -5,7 +5,7 @@ type Props = {
 
 defineProps<Props>()
 
-const { assetFilter } = storeToRefs(useAppStore())
+const { isOwned } = useFilters()
 </script>
 
 <template>
@@ -14,7 +14,7 @@ const { assetFilter } = storeToRefs(useAppStore())
       {{ $formatMessage('tokens_title') }}
     </h3>
     <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-3">
-      <TokenListLyxCard v-if="assetFilter === AssetFilter.owned" />
+      <TokenListLyxCard v-if="isOwned" />
       <TokenListCard
         v-for="(asset, index) in tokens"
         :key="index"

--- a/composables/useFilters.ts
+++ b/composables/useFilters.ts
@@ -1,0 +1,44 @@
+export const useFilters = () => {
+  const route = useRoute()
+  const viewedProfile = useProfile().viewedProfile()
+
+  // filters and their defaults
+  const filters = reactive<Filters>({
+    assetType: viewedProfile.value?.issuedAssets?.length ? 'created' : 'owned', // if profile has creations we show this as default
+  })
+
+  //--- getters
+  const isOwned = computed(() => filters.assetType === 'owned')
+
+  const isCreated = computed(() => filters.assetType === 'created')
+
+  //--- setters
+  const setFilters = (filters: Filters) => {
+    navigateTo({
+      path: route.path,
+      query: {
+        ...route.query,
+        ...filters,
+      },
+    })
+  }
+
+  watch(
+    () => route.query,
+    queryParams => {
+      const { assetType: assetTypeFilter } = queryParams
+
+      if (assetTypeFilter) {
+        filters.assetType = assetTypeFilter
+      }
+    },
+    { deep: true, immediate: true }
+  )
+
+  return {
+    filters,
+    setFilters,
+    isOwned,
+    isCreated,
+  }
+}

--- a/pages/[profileAddress]/index.vue
+++ b/pages/[profileAddress]/index.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { LSP4_TOKEN_TYPES } from '@lukso/lsp-smart-contracts'
 
-const { assetFilter } = storeToRefs(useAppStore())
+const { isOwned, isCreated, setFilters } = useFilters()
 const viewedProfileAddress = getCurrentProfileAddress()
 const { isMobile } = useDevice()
 
@@ -62,7 +62,7 @@ const ownedTokensCount = computed(
 const createdTokensCount = computed(() => tokensCreated.value?.length || 0)
 
 const tokens = computed(() => {
-  if (assetFilter.value === AssetFilter.owned) {
+  if (isOwned.value) {
     return tokensOwned.value
   }
   return tokensCreated.value
@@ -74,7 +74,7 @@ const ownedNftsCount = computed(() => nftsOwned.value?.length || 0)
 const createdNftsCount = computed(() => nftsCreated.value?.length || 0)
 
 const nfts = computed(() => {
-  if (assetFilter.value === AssetFilter.owned) {
+  if (isOwned.value) {
     return nftsOwned.value || []
   }
   return nftsCreated.value || []
@@ -91,22 +91,17 @@ const createdAssetsCount = computed(
 
 // empty states
 const hasEmptyCreators = computed(
-  () =>
-    assetFilter.value === AssetFilter.created &&
-    !createdNftsCount.value &&
-    !createdTokensCount.value
+  () => isCreated.value && !createdNftsCount.value && !createdTokensCount.value
 )
 
 const hasEmptyTokens = computed(
-  () =>
-    assetFilter.value === AssetFilter.owned ||
-    (assetFilter.value === AssetFilter.created && createdTokensCount.value)
+  () => isOwned.value || (isCreated && createdTokensCount.value)
 )
 
 const hasEmptyNfts = computed(
   () =>
-    (assetFilter.value === AssetFilter.owned && ownedNftsCount.value) ||
-    (assetFilter.value === AssetFilter.created && createdNftsCount.value)
+    (isOwned.value && ownedNftsCount.value) ||
+    (isCreated && createdNftsCount.value)
 )
 
 const isLoadingAssets = computed(() =>
@@ -128,10 +123,10 @@ const isLoadingAssets = computed(() =>
             <lukso-button
               :size="isMobile ? 'medium' : 'small'"
               variant="secondary"
-              :is-active="assetFilter === AssetFilter.owned ? true : undefined"
+              :is-active="isOwned ? true : undefined"
               is-full-width
               :count="ownedAssetsCount"
-              @click="assetFilter = AssetFilter.owned"
+              @click="setFilters({ assetType: 'owned' })"
               >{{ $formatMessage('asset_filter_owned_assets') }}</lukso-button
             >
           </li>
@@ -139,12 +134,10 @@ const isLoadingAssets = computed(() =>
             <lukso-button
               :size="isMobile ? 'medium' : 'small'"
               variant="secondary"
-              :is-active="
-                assetFilter === AssetFilter.created ? true : undefined
-              "
+              :is-active="isCreated ? true : undefined"
               is-full-width
               :count="createdAssetsCount"
-              @click="assetFilter = AssetFilter.created"
+              @click="setFilters({ assetType: 'created' })"
               >{{ $formatMessage('asset_filter_created_assets') }}</lukso-button
             >
           </li>

--- a/shared/enums.ts
+++ b/shared/enums.ts
@@ -14,11 +14,6 @@ export enum CACHE_KEY {
   HASHED_IMAGE = 'hashed-images',
 }
 
-export enum AssetFilter {
-  owned = 'owned',
-  created = 'created',
-}
-
 export enum STANDARDS {
   EOA = 'EOA',
   LSP3 = 'LSP3Profile',

--- a/stores/app.ts
+++ b/stores/app.ts
@@ -14,7 +14,6 @@ export const useAppStore = defineStore(
     const selectedChainId = ref<string>(DEFAULT_NETWORK_CHAIN_ID)
     const modal = ref<Modal>()
     const connectedProfileAddress = ref<Address>()
-    const assetFilter = ref(AssetFilter.owned)
 
     // statuses
     const isConnecting = ref(false)
@@ -76,7 +75,6 @@ export const useAppStore = defineStore(
       isConnected,
       isConnecting,
       isLoadedApp,
-      assetFilter,
       isTestnet,
       isSearchOpen,
     }

--- a/types/filters.ts
+++ b/types/filters.ts
@@ -1,0 +1,5 @@
+export type FiltersAssetType = 'owned' | 'created'
+
+export type Filters = {
+  assetType: FiltersAssetType
+}


### PR DESCRIPTION
### Ticket ID

[DEV-10979](https://app.clickup.com/t/2645698/DEV-10979)

### Description

- adds `assetType=owned|created` query param to select between created and owned assets. This will allow to create more personalized links.
- refactor filters into composition (prepare for next filters)
- when profile has created assets it will be displayed by default (unless there is `assetType` query param in url)
