### PR TITLE
fix: carousel blocks on  Safari

### DIFF
--- a/components/CreationsCarousel.vue
+++ b/components/CreationsCarousel.vue
@@ -38,10 +38,9 @@ const handleInit = (swiper: Swiper) => {
 
 const handleSlideChange = (swiper: Swiper) => {
   activeIndex.value = swiper.activeIndex
-  const address = swiper.slides[swiper.activeIndex].dataset.address as
+  activeAddress.value = swiper.slides[swiper.activeIndex].dataset.address as
     | Address
     | undefined
-  activeAddress.value = address
 }
 
 const styleVariants = tv({

--- a/components/CreationsCarousel.vue
+++ b/components/CreationsCarousel.vue
@@ -91,7 +91,8 @@ const styles = computed(() => {
     <Swiper
       v-if="isLoading"
       effect="coverflow"
-      :grab-cursor="true"
+      :grab-cursor="false"
+      :allow-touch-move="false"
       :centered-slides="false"
       :coverflow-effect="coverflowEffectOptions"
       :modules="[EffectCoverflow]"
@@ -107,7 +108,8 @@ const styles = computed(() => {
     <Swiper
       v-else
       effect="coverflow"
-      :grab-cursor="true"
+      :grab-cursor="false"
+      :allow-touch-move="false"
       :centered-slides="true"
       :coverflow-effect="coverflowEffectOptions"
       :modules="[EffectCoverflow, Navigation]"

--- a/components/CreationsCarousel.vue
+++ b/components/CreationsCarousel.vue
@@ -106,9 +106,10 @@ const styles = computed(() => {
       :modules="[EffectCoverflow]"
       :slides-per-view="isMobile ? 1 : SLIDES_PER_VIEW"
       :loop="false"
+      :enabled="false"
       class="w-[calc(100vw-48px)] lg:w-full"
     >
-      <SwiperSlide v-for="index in 6" :key="index" class="cursor-pointer pb-3"
+      <SwiperSlide v-for="index in 6" :key="index" class="pb-3"
         ><NftCard is-fixed-height
       /></SwiperSlide>
     </Swiper>

--- a/components/CreationsCarousel.vue
+++ b/components/CreationsCarousel.vue
@@ -9,11 +9,16 @@ type Props = {
 }
 
 const props = defineProps<Props>()
-const { isMobile } = useDevice()
+const { isMobile, isSafari } = useDevice()
 const activeIndex = ref(0)
+const activeAddress = ref<Address>()
 
-const handleCardClick = (asset: Asset) => {
-  navigateTo(tokenRoute(asset.address))
+const handleCardClick = (swiper: Swiper) => {
+  const _address = swiper?.clickedSlide?.dataset?.address as Address | undefined
+  // to fix safari bug where `clickedSlide` is undefined
+  const address = isSafari ? _address || activeAddress.value : _address
+
+  navigateTo(tokenRoute(address))
 }
 
 const isLoading = computed(() => props.assets?.some(asset => asset.isLoading))
@@ -33,6 +38,10 @@ const handleInit = (swiper: Swiper) => {
 
 const handleSlideChange = (swiper: Swiper) => {
   activeIndex.value = swiper.activeIndex
+  const address = swiper.slides[swiper.activeIndex].dataset.address as
+    | Address
+    | undefined
+  activeAddress.value = address
 }
 
 const styleVariants = tv({
@@ -92,7 +101,6 @@ const styles = computed(() => {
       v-if="isLoading"
       effect="coverflow"
       :grab-cursor="false"
-      :allow-touch-move="false"
       :centered-slides="false"
       :coverflow-effect="coverflowEffectOptions"
       :modules="[EffectCoverflow]"
@@ -109,7 +117,6 @@ const styles = computed(() => {
       v-else
       effect="coverflow"
       :grab-cursor="false"
-      :allow-touch-move="false"
       :centered-slides="true"
       :coverflow-effect="coverflowEffectOptions"
       :modules="[EffectCoverflow, Navigation]"
@@ -124,17 +131,17 @@ const styles = computed(() => {
       class="w-[calc(100vw-48px)] lg:w-full"
       @init="handleInit"
       @slide-change="handleSlideChange"
+      @click="handleCardClick"
     >
       <SwiperSlide
         v-for="asset in assets"
         :key="asset.address"
+        :data-address="asset.address"
         class="cursor-pointer select-none pb-3"
-        ><NftCard
-          :asset="asset"
-          @on-card-click="handleCardClick"
-          is-fixed-height
+        ><NftCard :asset="asset" is-fixed-height
       /></SwiperSlide>
     </Swiper>
+
     <!-- navigation -->
     <lukso-icon
       name="arrow-left-lg"

--- a/components/NftCard.vue
+++ b/components/NftCard.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
 type Props = {
-  asset: Asset
+  asset?: Asset
   isFixedHeight?: boolean
 }
 
 type Emits = {
-  (event: 'on-card-click', asset: Asset): void
-  (event: 'on-image-click', asset: Asset): void
+  (event: 'on-card-click', asset?: Asset): void
+  (event: 'on-image-click', asset?: Asset): void
 }
 
 const props = defineProps<Props>()

--- a/components/NftCard.vue
+++ b/components/NftCard.vue
@@ -27,8 +27,11 @@ const assetTokenId = computed(() => {
     @click="emits('on-card-click', asset)"
     ><div slot="content">
       <AssetImage
-        class="min-h-[360px] cursor-pointer rounded-t-12 md:min-h-[260px]"
-        :class="{ 'max-h-[360px] md:max-h-[260px]': isFixedHeight }"
+        class="min-h-[360px] rounded-t-12 md:min-h-[260px]"
+        :class="{
+          'max-h-[360px] md:max-h-[260px]': isFixedHeight,
+          'cursor-pointer': asset?.address,
+        }"
         :image="assetImage"
         @click="emits('on-image-click', asset)"
       />

--- a/components/NftCard.vue
+++ b/components/NftCard.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 type Props = {
   asset: Asset
-  isFixedHeight: boolean
+  isFixedHeight?: boolean
 }
 
 type Emits = {

--- a/components/TokenListCard.vue
+++ b/components/TokenListCard.vue
@@ -75,7 +75,7 @@ const isLoadedMetadata = computed(
               v-if="isLoadedMetadata"
               size="medium"
               :profile-address="token?.address"
-              :profile-url="assetImage?.url"
+              :profile-url="isLoadedAsset ? assetImage?.url : undefined"
               has-identicon
             ></lukso-profile>
             <AppPlaceholderCircle v-else class="size-14" />

--- a/composables/useToken.ts
+++ b/composables/useToken.ts
@@ -1,5 +1,4 @@
 import { useQueries } from '@tanstack/vue-query'
-import ABICoder from 'web3-eth-abi'
 import { keccak256 } from 'web3-utils'
 
 import { browserProcessMetadata } from '@/utils/processMetadata'
@@ -58,7 +57,7 @@ export function useToken() {
                 ? queryGetData({
                     // 4
                     chainId,
-                    address: ABICoder.decodeParameter(
+                    address: decodeParameter(
                       'address',
                       tokenId
                     ).toLowerCase() as Address,
@@ -69,7 +68,7 @@ export function useToken() {
                 ? queryGetData({
                     // 5
                     chainId,
-                    address: ABICoder.decodeParameter(
+                    address: decodeParameter(
                       'address',
                       tokenId
                     ).toLowerCase() as Address,
@@ -136,7 +135,7 @@ export function useToken() {
                 ? queryGetData({
                     // 9
                     chainId,
-                    address: ABICoder.decodeParameter(
+                    address: decodeParameter(
                       'address',
                       tokenId
                     ).toLowerCase() as Address,

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "stylelint-config-standard-scss": "13.0.0",
     "stylelint-prettier": "5.0.0",
     "stylelint-scss": "6.2.1",
+    "swiper": "11.1.4",
     "tailwind-variants": "^0.2.1",
     "three": "^0.162.0",
     "typechain": "^8.3.2",
@@ -127,7 +128,8 @@
     "@tanstack/query-core": "^5.20.5",
     "web3-bzz": "~1.10.3",
     "web3-shh": "~1.10.3",
-    "web3": "~1.10.3"
+    "web3": "~1.10.3",
+    "swiper": "11.1.4"
   },
   "lint-staged": {
     "*.{ts,js,vue,json,yaml,yml}": [

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "stylelint-config-standard-scss": "13.0.0",
     "stylelint-prettier": "5.0.0",
     "stylelint-scss": "6.2.1",
-    "swiper": "11.1.4",
+    "swiper": "~11.1.4",
     "tailwind-variants": "^0.2.1",
     "three": "^0.162.0",
     "typechain": "^8.3.2",
@@ -129,7 +129,7 @@
     "web3-bzz": "~1.10.3",
     "web3-shh": "~1.10.3",
     "web3": "~1.10.3",
-    "swiper": "11.1.4"
+    "swiper": "~11.1.4"
   },
   "lint-staged": {
     "*.{ts,js,vue,json,yaml,yml}": [

--- a/utils/__tests__/decodeParameter.spec.ts
+++ b/utils/__tests__/decodeParameter.spec.ts
@@ -1,5 +1,5 @@
-import ABICoder from 'web3-eth-abi'
 import { describe, expect, test, vi } from 'vitest'
+import ABICoder from 'web3-eth-abi'
 import { decodeParameter } from '../decodeParameter'
 
 describe('decodeParameter function', () => {

--- a/utils/__tests__/decodeParameter.spec.ts
+++ b/utils/__tests__/decodeParameter.spec.ts
@@ -1,0 +1,62 @@
+import ABICoder from 'web3-eth-abi'
+import { describe, expect, test, vi } from 'vitest'
+import { decodeParameter } from '../decodeParameter'
+
+describe('decodeParameter function', () => {
+  test('returns decoded uint256 value when decoding succeeds', () => {
+    const param = 'uint256'
+    const value =
+      '0x0000000000000000000000000000000000000000000000000000000000000001'
+    const expectedResult = '1'
+
+    expect(decodeParameter(param, value)).toEqual(expectedResult)
+  })
+
+  test('returns decoded address value when decoding succeeds', () => {
+    const param = 'address'
+    const value =
+      '0x000000000000000000000000a34fa53aa34990080b83fa404126d4295074f35b'
+    const expectedResult = '0xa34fA53aa34990080B83FA404126D4295074f35B'
+
+    expect(decodeParameter(param, value)).toEqual(expectedResult)
+  })
+
+  test('returns empty string when decoding fails due to invalid parameter type', () => {
+    const param = 'invalidType'
+    const value =
+      '0x0000000000000000000000000000000000000000000000000000000000000001'
+
+    expect(decodeParameter(param, value)).toEqual('')
+  })
+
+  test('returns empty string when decoding fails due to invalid value', () => {
+    const param = 'uint256'
+    const value = 'invalidValue'
+
+    expect(decodeParameter(param, value)).toEqual('')
+  })
+
+  test('returns empty string when decoding fails due to ABICoder error', () => {
+    // Mock ABICoder.decodeParameter to throw an error
+    const originalDecodeParameter = ABICoder.decodeParameter
+    ABICoder.decodeParameter = vi.fn().mockImplementation(() => {
+      throw new Error('Mock ABI Coder error')
+    })
+
+    const param = 'uint256'
+    const value =
+      '0x0000000000000000000000000000000000000000000000000000000000000001'
+
+    expect(decodeParameter(param, value)).toEqual('')
+
+    // Restore original ABICoder.decodeParameter
+    ABICoder.decodeParameter = originalDecodeParameter
+  })
+
+  test('returns empty string when decoding fails due to invalid input', () => {
+    const param = ''
+    const value = ''
+
+    expect(decodeParameter(param, value)).toEqual('')
+  })
+})

--- a/utils/decodeParameter.ts
+++ b/utils/decodeParameter.ts
@@ -1,0 +1,17 @@
+import ABICoder from 'web3-eth-abi'
+
+/**
+ * Wrap decode parameter function into try catch block to not break app when decoding fails
+ *
+ * @param param
+ * @param value
+ * @returns
+ */
+export const decodeParameter = (param: string, value: string) => {
+  try {
+    return ABICoder.decodeParameter(param, value)
+  } catch (error) {
+    console.error(`Couldn't decode ${param} with value ${value}`, error)
+    return ''
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -18857,10 +18857,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"swiper@npm:^10.2.0":
-  version: 10.3.1
-  resolution: "swiper@npm:10.3.1"
-  checksum: 979c23ff3965a0583f75e65b788269f78f9e65f3089f20747216a6334ee7a1d5bee361ee698e7acc6060a140b5443801aec6fcd6f3095ee3acc31771b425124e
+"swiper@npm:11.1.4":
+  version: 11.1.4
+  resolution: "swiper@npm:11.1.4"
+  checksum: c4ecf10dc447921ec8c58a8f9a2b76f1ca6dddbc81aff1caafb8c8504460c9e934a9f709113a757ca91dd0305d2e25337fc512206813ea333492415d7a144757
   languageName: node
   linkType: hard
 
@@ -19926,6 +19926,7 @@ __metadata:
     stylelint-config-standard-scss: "npm:13.0.0"
     stylelint-prettier: "npm:5.0.0"
     stylelint-scss: "npm:6.2.1"
+    swiper: "npm:11.1.4"
     tailwind-variants: "npm:^0.2.1"
     three: "npm:^0.162.0"
     typechain: "npm:^8.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -18857,7 +18857,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"swiper@npm:11.1.4":
+"swiper@npm:~11.1.4":
   version: 11.1.4
   resolution: "swiper@npm:11.1.4"
   checksum: c4ecf10dc447921ec8c58a8f9a2b76f1ca6dddbc81aff1caafb8c8504460c9e934a9f709113a757ca91dd0305d2e25337fc512206813ea333492415d7a144757
@@ -19926,7 +19926,7 @@ __metadata:
     stylelint-config-standard-scss: "npm:13.0.0"
     stylelint-prettier: "npm:5.0.0"
     stylelint-scss: "npm:6.2.1"
-    swiper: "npm:11.1.4"
+    swiper: "npm:~11.1.4"
     tailwind-variants: "npm:^0.2.1"
     three: "npm:^0.162.0"
     typechain: "npm:^8.3.2"


### PR DESCRIPTION
### Ticket ID

[DEV-11159](https://app.clickup.com/t/2645698/DEV-11159)

### Description

Turns out that real problem is that some assets has incorrectly encoded `tokenId` and unhandled exception from the decoder break the UI and carousel too. Issue only happens on first load, once data is cached it pass the check.

Example profiles: 
https://universalprofile.cloud/0xaE4FeE208eB0ed7b3491511059Ba31964314AeCB
https://universalprofile.cloud/0xfa39A2207f1d1C1ceC32502000481F0feF660384

On Safari there is still issue where user can't click on the carousel item to visit details view, it works only with middle slide. This seem to be bug in the carousel it self.


